### PR TITLE
Update describe EC2 instances to only use Online instances

### DIFF
--- a/commands/list/instances.go
+++ b/commands/list/instances.go
@@ -33,7 +33,6 @@ func listInstancesCli(c *cli.Context) error {
 	}
 
 	UI.Debugf("DescribeInstances response: %+v\n", instances)
-
 	// If List flag is set then print a comma delimited list of instances
 	if c.Bool("list") {
 		instanceIDs := make([]string, len(instances))

--- a/pkg/ec2utils/describe.go
+++ b/pkg/ec2utils/describe.go
@@ -20,13 +20,22 @@ type Instance struct {
 func genSSMFilters(filters string) ([]*ssm.InstanceInformationStringFilter, error) {
 	filtersList := strings.Split(filters, ",")
 
-	ssmFilters := make([]*ssm.InstanceInformationStringFilter, len(filtersList))
-	i := 0
+	ssmFilters := make([]*ssm.InstanceInformationStringFilter, len(filtersList)+1)
+	ssmFilters[0] = &ssm.InstanceInformationStringFilter{
+		Key:    aws.String("PingStatus"),
+		Values: []*string{aws.String("Online")},
+	}
+
+	i := 1
 	for _, filter := range filtersList {
 		filterInfo := strings.Split(filter, "=")
 
 		if len(filterInfo) != 2 {
 			return ssmFilters, fmt.Errorf("Invalid filter \"%s\", exect Key=Value", filter)
+		}
+
+		if filterInfo[0] == "PingStatus" {
+			return ssmFilters, fmt.Errorf("PingStatus is static filter, cannot be altererd")
 		}
 
 		ssmFilters[i] = &ssm.InstanceInformationStringFilter{


### PR DESCRIPTION
This prevents issues with SSM returning EC2 instances that are still
registered with SSM but no longer exist in EC2. Since maestro is largely
meant to be used orchestrating instances it makes sense that only instances
able to accept SSM commands would be included in the list.