### PR TITLE
Fix S3 bucket regex regression

### DIFF
--- a/pkg/ssmrunner/execmd.go
+++ b/pkg/ssmrunner/execmd.go
@@ -18,7 +18,7 @@ import (
 const (
 	OutputS3KeyPrefix = `[a-zA-Z0-9]+\/i-[a-zA-Z0-9]+\/[a-zA-Z0-9\.]+\/[a-zA-Z0-9\.]+\/`
 	PollInterval      = 30
-	S3UrlRegex        = `^https:\/\/s3(\.|\-)([a-z]+\-[a-z]+\-[0-9])?.amazonaws.com\/([a-zA-Z\-\_0-9]+)\/([a-zA-Z\-\_\/0-9\.\%]+)$`
+	S3UrlRegex        = `^https:\/\/s3(\.|\-)?([a-z]+\-[a-z]+\-[0-9])?.amazonaws.com\/([a-zA-Z\-\_0-9]+)\/([a-zA-Z\-\_\/0-9\.\%]+)$`
 )
 
 type ExecutionError struct {

--- a/pkg/ssmrunner/execmd_test.go
+++ b/pkg/ssmrunner/execmd_test.go
@@ -1,0 +1,25 @@
+package ssmrunner
+
+import (
+	"regexp"
+	"testing"
+)
+
+func TestS3Regex(t *testing.T) {
+	bucketURLs := map[string]string{
+		"regionDomain":    "https://s3-us-west-2.amazonaws.com/maestro-0r5f141055052e5/6daa402c-2242-491a-9272-9287ffd9f492/i-0234sd0sdfd0/awsrunShellScript/0.runShellScript/stdout",
+		"regionSubDomain": "https://s3.eu-central-1.amazonaws.com/maestro-0r5f141055052e5/6daa402c-2242-491a-9272-9287ffd9f492/i-0234sd0sdfd0/awsrunShellScript/0.runShellScript/stdout",
+		"usStandard":      "https://s3.amazonaws.com/maestro-0r5f141055052e5/6daa402c-2242-491a-9272-9287ffd9f492/i-0234sd0sdfd0/awsrunShellScript/0.runShellScript/stdout",
+	}
+
+	for testName, url := range bucketURLs {
+		t.Run(testName, func(t *testing.T) {
+			re := regexp.MustCompile(S3UrlRegex)
+			result := re.FindStringSubmatch(url)
+
+			if len(result) != 5 {
+				t.Errorf("expected regex to find 5 groups: %d found", len(result))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This fixes a regex bug that was introduced for the US East 1 region
and adds a few tests to prevent future regressions.